### PR TITLE
Add notes on integrating Cargo with external build systems

### DIFF
--- a/rls/Build script capabilities.md
+++ b/rls/Build script capabilities.md
@@ -1,0 +1,74 @@
+# Integrating with other build systems
+## Idea #1
+Allow specifying file outputs to build scripts (BS) in the Cargo manifest (and/or include input files?)
+```toml
+[build]
+outputs = [ "file1", "file2" ]
+```
+
+Clearly defines and solves one of the main use cases for build scripts - code generation.
+
+1. If the output files are not specified, always consider BS to be dirty
+    * (_good_) correct (but may be inefficient)
+    * (_good_) strongly encourages users to specify BS outputs themselves to save rebuild cycles
+    * (_bad_) doesn't work well with *modify/prepare external/OS environment* (use cases?)
+    * (_bad_) doesn't cover the case where BS outputs and passes down relevant env vars
+        * (_solvable?_) Like with current BS output, we could treat generated env vars as a well defined, special-cased file output implicitly needed by all the target kinds
+2. Don't allow for `build.outputs` and existing (pre-build script run) package files to overlap
+   * (_good_) if we allow that, the interaction is poor - it's possible that build scripts will be considered _fresh_ because the outputs exist before running it but the intention was to _preprocess_ input files
+3. (Prior art) Required by numerous build systems:
+    * [mozbuild](https://dxr.mozilla.org/mozilla-central/rev/c291143e24019097d087f9307e59b49facaf90cb/python/mozbuild/mozbuild/backend/cargo_build_defs.py) ([context](https://internals.rust-lang.org/t/build-script-capabilities/8635/5?u=xanewok))
+    * [Buck](https://buckbuild.com/rule/genrule.html#out) (`genrule.out`)
+    * [Bazel](https://docs.bazel.build/versions/master/be/general.html#genrule.outs) (`genrule.outs`)
+    * [GN](https://chromium.googlesource.com/chromium/src/tools/gn/+/48062805e19b4697c5fbd926dc649c78b6aaa138/docs/language.md#executing-scripts) (`action.outputs`)
+
+## Idea #2
+Restrict generating files only to (Cargo's) `$OUT_DIR`
+   * (_good_) doesn't clobber package directory
+   * (_good_) `cargo clean` workflow always works as expected
+   * (_bad_) restricts possible workflow (preprocessor use cases come to mind, e.g. generate in-tree `${FILE}.i` for each source `${FILE}`)
+
+## Idea #3
+Restrict general build script capabilities
+* Sandboxed execution
+* Compile BS with a Cargo util crate (providing API equivalent to printing `cargo:` keys, allowed access to files etc.)
+* Emit BS MIR and only allow execution of a "safe" subset of Rust programs
+    * Detect and allow `File::open` and similar APIs only with path literals
+        * (_bad_) no `rustc` compile-time errors (diagnostics emitted by Cargo)
+        * (_bad_) hardcoded APIs, easy to miss (e.g. `OpenOptions` can also open files)
+        * (_bad_) restricts usage, e.g. can't create dynamic `${i}.txt` files
+
+## Idea #4
+Solve BS use cases by implementing native/declarative solutions
+
+1. Conditional compilation driven by `rustc` version (solved by [RFC #2523](https://github.com/rust-lang/rfcs/pull/2523), [cuviper/autocfg](https://github.com/cuviper/autocfg) crate)
+
+   1. ([libc](https://github.com/rust-lang/libc/blob/master/build.rs)) - only use case (13k DLs/day)
+   2. ([rand](https://github.com/rust-random/rand/blob/master/build.rs)) - only use case (20k DLs/day)
+   3. ([serde](https://github.com/serde-rs/serde/blob/master/serde/build.rs)) - only use case (12k DLs/day)
+   4. ([regex](https://github.com/rust-lang/regex/blob/master/build.rs)) - only use case (12k DLs/day)
+   5. ([num-traits](https://github.com/rust-num/num-traits/blob/master/build.rs)) - only use case (10k DLs/day)
+2. Dependence on env vars
+    1. `librustc_driver/build.rs`
+        1. `CFG_RELEASE`
+        2. `CFG_VERSION`
+        3. `CFG_VER_DATE`
+        4. `CFG_VER_HASH`
+    2. `librustc/build.rs`
+        1. `CFG_LIBDIR_RELATIVE`
+        2. `CFG_COMPILER_HOST_TRIPLE`
+        3. `RUSTC_VERIFY_LLVM_IR` (converted into `cfg` flag)
+3. feature-specific `cfg` flags
+    1. `dlmalloc/build.rs`
+        1. `feature = "debug"` -> `cfg` flag `debug_assertions`
+4. target-specific `link-lib`
+    1. `libunwind/build.rs`
+    2. `libstd/build.rs`
+    3. `librustc_llvm/build.rs` (partially)
+2. Building/linking native dependencies (`*-sys` crates)
+   1. [joshtriplett/metadeps](https://github.com/joshtriplett/metadeps) - Run pkg-config from declarative dependencies in Cargo.toml
+
+---
+Relevant:
+* chromium's disclaimer against `exec_script` rule types
+https://chromium.googlesource.com/chromium/src/+/master/.gn#622

--- a/rls/Cargo rule translation.md
+++ b/rls/Cargo rule translation.md
@@ -1,0 +1,54 @@
+Difficulties for translating the rules (Buck -> Cargo)
+## `build.rs` (explained in-depth elsewhere)
+* missing build outputs
+* dependence on env vars
+## Multiple libraries
+Cargo package (single directory) can't contain multiple libraries.
+
+Prior art:
+* [internals post (2015)](https://internals.rust-lang.org/t/how-about-changing-lib-to-lib-to-allow-multiple-library-in-a-crate/2022)
+* [internals post (2018)](https://internals.rust-lang.org/t/multiple-libraries-in-a-cargo-project/8259)
+
+Possible workaround: Create a workspace with multiple library 'packages'
+## Dependencies per-crate target (instead of per-package)
+Cargo can only express dependencies on a package level
+## Can't easily specify RUSTFLAGS per crate target
+Cargo [can specify](https://doc.rust-lang.org/cargo/reference/config.html#configuration-keys) additional `RUSTFLAGS` declaratively per *target-triple* in a local `.cargo/config`.
+```toml
+# For the following sections, $triple refers to any valid target triple, not the
+# literal string "$triple", and it will apply whenever that target triple is
+# being compiled to. 'cfg(...)' refers to the Rust-like `#[cfg]` syntax for
+# conditional compilation.
+[target.$triple]
+
+#...
+
+# custom flags to pass to all compiler invocations that target $triple
+# this value overrides build.rustflags when both are present
+rustflags = ["..", ".."]
+
+[target.'cfg(...)']
+# Similar for the $triple configuration, but using the `cfg` syntax.
+# If several `cfg` and $triple targets are candidates, then the rustflags
+# are concatenated. The `cfg` syntax only applies to rustflags, and not to
+# linker.
+rustflags = ["..", ".."]
+```
+
+## Can't specify linker args per-target
+* [RFC #1766](https://github.com/rust-lang/rfcs/issues/1766)
+* `link_args` in `rustc` - https://github.com/rust-lang/rust/issues/29596
+
+# Other systems
+## Bazel
+How is it doing it? Rust support seems to be lacking (Rust code not officially approved for the Google monorepo?)
+However Google Cloud uses Bazel - ppl should be using Rust there?
+## GN
+How Fuchsia folk integrate Rust?
+
+[`rustc_library`](https://fuchsia.googlesource.com/build/+/master/rust/rustc_library.gni)
+and
+[`rustc_binary`](https://fuchsia.googlesource.com/build/+/master/rust/rustc_binary.gni)
+rules (shared
+[`rustc_artifact`](https://fuchsia.googlesource.com/build/+/master/rust/rustc_artifact.gni)
+rules similar to Buck/Bazel)

--- a/rls/Detecting input files for crate.md
+++ b/rls/Detecting input files for crate.md
@@ -1,0 +1,19 @@
+# Detecting input files for crate
+What affects input files?
+1. `include*!` built-in macros
+2. `#[doc(include = "path")]` attribute
+3. Module files
+4. (_indirectly_) Extern crates
+
+Points 1 and 2 are easily solvable (resolved during expansion phase - insert dummy nodes and register dependencies).
+(https://github.com/Xanewok/rust/tree/dep-info-allow-missing-files)
+
+However, module files and extern crates are tricky.
+
+Firstly, parsing modules can produce additional `include!` directives and create (path) items.
+Existence of paths can further drive conditional compilation on `include*!`, `mod MOD;` items etc.
+([RFC #2523](https://github.com/rust-lang/rfcs/pull/2523))
+
+Since extern crates obviously import defined paths, the conditional compilation can be driven using those, which means we effectively need to have our dependencies compiled (at least metadata) to be able to resolve the conditional compilation - this is required to know what is `include!`d and so on.
+
+Until [RFC #2523](https://github.com/rust-lang/rfcs/pull/2523) is merged, a package only needs to execute its build script to know its inputs.

--- a/rls/Splitting Cargo into components.md
+++ b/rls/Splitting Cargo into components.md
@@ -1,0 +1,25 @@
+## Build backend
+One of the main goals would be to allow building Rust with different build _backends_.
+
+Idea: Split Cargo into
+```
+                       resolution/download
+Cargo.toml -> [Cargo] ----------------------> abstract build plan -> [Build backend]
+```
+Would this mean that `cargo build` would shell out to a respective backend as part of its routine (e.g. call `cargo-buckend --plan=file.json`)?
+
+Backends would be responsible for translating the intermediate rules to the ones the build executor understands (in this model `build.rs` would be an implementation detail for Cargo build executor).
+
+
+### Resolution
+Cargo resolves optional dependencies, concrete package versions and feature set as part of its resolution.
+
+How does it affect integration (especially vendoring)?
+
+Translating and commiting rules _a priori_ for the external build system presumably makes the maintenance easier but makes some Cargo-specific workflow harder: in particular, because external build system rules correspond to a Cargo post-resolution (lockfile) state.
+
+How would `cargo update -p <pkg>` in post-translation environment work? Many obstacles:
+* We'd need to understand external rules
+* synthesize an internal Cargo lockfile
+* How to get package *constraints*? (for all we know all dep constraints could be of concrete `=1.2.3` format)
+* Retranslate and clobber existing build system rules?


### PR DESCRIPTION
Copying over notes from https://github.com/Xanewok/cargo-external-integration-notes.

Should I create a separate `cargo` directory for those?

r? @nrc